### PR TITLE
Config: Using the frontend url as the service base

### DIFF
--- a/.docker/WebUI/Configuration/Configuration.jsx
+++ b/.docker/WebUI/Configuration/Configuration.jsx
@@ -2,8 +2,11 @@
 
     export default {
         // Arriba Service URL to query
-        // Hardcode to the name of your service. Use port 42784 for HTTP, 42785 for HTTPS.
-        url: "http://" + window.location.hostname + ":42784",
+        // Hardcode to the name of your service. Use port 42784 for HTTP, 42785 for HTTPS.        
+        url: window.location.protocol + "//" + 
+             window.location.hostname + 
+             (window.location.port > 0 ? ":" + window.location.port : "" ) + 
+             "/data",
 
         // Name of tool to show [top right and elsewhere]
         toolName: "CSEng",

--- a/src/Arriba/Arriba.Web/configuration/Configuration.jsx
+++ b/src/Arriba/Arriba.Web/configuration/Configuration.jsx
@@ -6,7 +6,11 @@
     export default {
         // Arriba Service URL to query
         // Hardcode to the name of your service. Use port 42784 for HTTP, 42785 for HTTPS.
-        url: window.location.protocol + "//" + window.location.hostname + "/data",
+        url: window.location.protocol + "//" + 
+             window.location.hostname + 
+             (window.location.port > 0 ? ":" + window.location.port : "" ) + 
+             "/data",
+
 
         // Name of tool to show [top right and elsewhere]
         toolName: "Arriba",


### PR DESCRIPTION
Instead of using the protocol and port fixed this change uses the current frontend application url as a Arria Server base.

It works specially when using the proxy like NGINX