### PR TITLE
TESTING: Enable disabled tests and fix them

### DIFF
--- a/src/Arriba/Arriba.Test/Model/Query/QueryIntelliSenseTests.cs
+++ b/src/Arriba/Arriba.Test/Model/Query/QueryIntelliSenseTests.cs
@@ -357,8 +357,7 @@ namespace Arriba.Test.Model.Query
             return output.ToString();
         }
 
-        [TestMethod]
-        [Ignore("Needs fix while converting to dotnetcore")]
+        [TestMethod]        
         public void DistributionQuery_Rounding()
         {
             Assert.AreEqual(12, DistributionQuery.Bucketer<bool>.Round(12));

--- a/src/Arriba/Arriba.Test/Model/Query/QueryIntelliSenseTests.cs
+++ b/src/Arriba/Arriba.Test/Model/Query/QueryIntelliSenseTests.cs
@@ -374,11 +374,11 @@ namespace Arriba.Test.Model.Query
             Assert.AreEqual(123.0, DistributionQuery.Bucketer<bool>.Round(123.4));
             Assert.AreEqual(1230, DistributionQuery.Bucketer<bool>.Round(1234.5));
 
-            Assert.AreEqual("5/22/2017 12:00:00 AM", DistributionQuery.Bucketer<bool>.Round(DateTime.Parse("2017-05-22 3:33:35 PM"), TimeSpan.FromDays(1)).ToString());
-            Assert.AreEqual("5/22/2017 4:00:00 PM", DistributionQuery.Bucketer<bool>.Round(DateTime.Parse("2017-05-22 3:33:35 PM"), TimeSpan.FromHours(1)).ToString());
-            Assert.AreEqual("5/22/2017 3:34:00 PM", DistributionQuery.Bucketer<bool>.Round(DateTime.Parse("2017-05-22 3:33:35 PM"), TimeSpan.FromMinutes(1)).ToString());
-            Assert.AreEqual("5/22/2017 3:33:35 PM", DistributionQuery.Bucketer<bool>.Round(DateTime.Parse("2017-05-22 3:33:35 PM"), TimeSpan.FromSeconds(1)).ToString());
-
+            string dateFormat = "MM/dd/yyyy HH:mm:ss";
+            Assert.AreEqual("05/22/2017 00:00:00", DistributionQuery.Bucketer<bool>.Round(DateTime.Parse("2017-05-22 3:33:35 PM"), TimeSpan.FromDays(1)).ToString(dateFormat));
+            Assert.AreEqual("05/22/2017 16:00:00", DistributionQuery.Bucketer<bool>.Round(DateTime.Parse("2017-05-22 3:33:35 PM"), TimeSpan.FromHours(1)).ToString(dateFormat));
+            Assert.AreEqual("05/22/2017 15:34:00", DistributionQuery.Bucketer<bool>.Round(DateTime.Parse("2017-05-22 3:33:35 PM"), TimeSpan.FromMinutes(1)).ToString(dateFormat));
+            Assert.AreEqual("05/22/2017 15:33:35", DistributionQuery.Bucketer<bool>.Round(DateTime.Parse("2017-05-22 3:33:35 PM"), TimeSpan.FromSeconds(1)).ToString(dateFormat));
             Assert.AreEqual("123.00:00:00", DistributionQuery.Bucketer<bool>.Round(TimeSpan.Parse("123.10:41:51.6789"), TimeSpan.FromDays(1)).ToString());
             Assert.AreEqual("123.11:00:00", DistributionQuery.Bucketer<bool>.Round(TimeSpan.Parse("123.10:41:51.6789"), TimeSpan.FromHours(1)).ToString());
             Assert.AreEqual("123.10:42:00", DistributionQuery.Bucketer<bool>.Round(TimeSpan.Parse("123.10:41:51.6789"), TimeSpan.FromMinutes(1)).ToString());

--- a/src/Arriba/Arriba.Test/Serialization/CSV/CsvReaderTests.cs
+++ b/src/Arriba/Arriba.Test/Serialization/CSV/CsvReaderTests.cs
@@ -138,7 +138,6 @@ namespace Arriba.Test.Csv
         }
 
         [TestMethod]
-        [Ignore("Needs fix while converting to dotnetcore")]
         public void ParseQuotedNewLine()
         {
             // This is realy """A""","B","C"

--- a/src/Arriba/Arriba.Test/Serialization/CSV/CsvReaderTests.cs
+++ b/src/Arriba/Arriba.Test/Serialization/CSV/CsvReaderTests.cs
@@ -141,7 +141,7 @@ namespace Arriba.Test.Csv
         public void ParseQuotedNewLine()
         {
             // This is realy """A""","B","C"
-            string content = "\"A\r\nA\",\"B\",\"C\"";
+            string content = $"\"A{Environment.NewLine}A\",\"B\",\"C\"";
 
             var settings = new CsvReaderSettings()
             {
@@ -155,7 +155,7 @@ namespace Arriba.Test.Csv
                 var rows = reader.Rows.ToArray();
 
 
-                Assert.AreEqual("A\r\nA", rows[0][0].ToString());
+                Assert.AreEqual($"A{Environment.NewLine}A", rows[0][0].ToString());
                 Assert.AreEqual("B", rows[0][1].ToString());
                 Assert.AreEqual("C", rows[0][2].ToString());
             }
@@ -227,9 +227,9 @@ namespace Arriba.Test.Csv
 
             using (StreamWriter writer = new StreamWriter(ms, Encoding.UTF8, 1024, true))
             {
-                foreach (var line in content.Split('\n'))
+                foreach (var line in content.Split(Environment.NewLine))
                 {
-                    var finalLine = line.Trim().TrimEnd('\r');
+                    var finalLine = line.Trim();
 
                     if (String.IsNullOrWhiteSpace(finalLine))
                     {

--- a/src/Arriba/Arriba.Test/Structures/ValueTests.cs
+++ b/src/Arriba/Arriba.Test/Structures/ValueTests.cs
@@ -56,16 +56,16 @@ namespace Arriba.Test.Structures
             // Number Limits - ensure upconvert but don't downconvert; no unsigned representation for negative values
             Assert.AreEqual(String.Format("string:{0}, ByteBlock:{0}, double:{0}", double.MaxValue), TryAllConversions(double.MaxValue));
             Assert.AreEqual(String.Format("string:{0}, ByteBlock:{0}, double:{0}", double.MaxValue), TryAllConversions_ValueTypeReference(double.MaxValue));
-            Assert.AreEqual(String.Format("string:{0}, ByteBlock:{0}, double:3.40282346638529E+38, float:{0}", float.MaxValue), TryAllConversions(float.MaxValue));
-            Assert.AreEqual(String.Format("string:{0}, ByteBlock:{0}, double:3.40282346638529E+38, float:{0}", float.MaxValue), TryAllConversions_ValueTypeReference(float.MaxValue));
-            Assert.AreEqual(String.Format("string:{0}, ByteBlock:{0}, double:1.84467440737096E+19, float:1.844674E+19, ulong:{0}", ulong.MaxValue), TryAllConversions(ulong.MaxValue));
-            Assert.AreEqual(String.Format("string:{0}, ByteBlock:{0}, double:1.84467440737096E+19, float:1.844674E+19, ulong:{0}", ulong.MaxValue), TryAllConversions_ValueTypeReference(ulong.MaxValue));
-            Assert.AreEqual(String.Format("string:{0}, ByteBlock:{0}, double:9.22337203685478E+18, float:9.223372E+18, ulong:{0}, long:{0}", long.MaxValue), TryAllConversions(long.MaxValue));
-            Assert.AreEqual(String.Format("string:{0}, ByteBlock:{0}, double:9.22337203685478E+18, float:9.223372E+18, ulong:{0}, long:{0}", long.MaxValue), TryAllConversions_ValueTypeReference(long.MaxValue));
-            Assert.AreEqual(String.Format("string:{0}, ByteBlock:{0}, double:{0}, float:4.294967E+09, ulong:{0}, long:{0}, uint:{0}", uint.MaxValue), TryAllConversions(uint.MaxValue));
-            Assert.AreEqual(String.Format("string:{0}, ByteBlock:{0}, double:{0}, float:4.294967E+09, ulong:{0}, long:{0}, uint:{0}", uint.MaxValue), TryAllConversions_ValueTypeReference(uint.MaxValue));
-            Assert.AreEqual(String.Format("string:{0}, ByteBlock:{0}, double:{0}, float:2.147484E+09, ulong:{0}, long:{0}, uint:{0}, int:{0}", int.MaxValue), TryAllConversions(int.MaxValue));
-            Assert.AreEqual(String.Format("string:{0}, ByteBlock:{0}, double:{0}, float:2.147484E+09, ulong:{0}, long:{0}, uint:{0}, int:{0}", int.MaxValue), TryAllConversions_ValueTypeReference(int.MaxValue));
+            Assert.AreEqual(String.Format("string:{0}, ByteBlock:{0}, double:3.4028234663852886E+38, float:{0}", float.MaxValue), TryAllConversions(float.MaxValue));
+            Assert.AreEqual(String.Format("string:{0}, ByteBlock:{0}, double:3.4028234663852886E+38, float:{0}", float.MaxValue), TryAllConversions_ValueTypeReference(float.MaxValue));
+            Assert.AreEqual(String.Format("string:{0}, ByteBlock:{0}, double:1.8446744073709552E+19, float:1.8446744E+19, ulong:{0}", ulong.MaxValue), TryAllConversions(ulong.MaxValue));
+            Assert.AreEqual(String.Format("string:{0}, ByteBlock:{0}, double:1.8446744073709552E+19, float:1.8446744E+19, ulong:{0}", ulong.MaxValue), TryAllConversions_ValueTypeReference(ulong.MaxValue));
+            Assert.AreEqual(String.Format("string:{0}, ByteBlock:{0}, double:9.223372036854776E+18, float:9.223372E+18, ulong:{0}, long:{0}", long.MaxValue), TryAllConversions(long.MaxValue));
+            Assert.AreEqual(String.Format("string:{0}, ByteBlock:{0}, double:9.223372036854776E+18, float:9.223372E+18, ulong:{0}, long:{0}", long.MaxValue), TryAllConversions_ValueTypeReference(long.MaxValue));
+            Assert.AreEqual(String.Format("string:{0}, ByteBlock:{0}, double:{0}, float:4.2949673E+09, ulong:{0}, long:{0}, uint:{0}", uint.MaxValue), TryAllConversions(uint.MaxValue));
+            Assert.AreEqual(String.Format("string:{0}, ByteBlock:{0}, double:{0}, float:4.2949673E+09, ulong:{0}, long:{0}, uint:{0}", uint.MaxValue), TryAllConversions_ValueTypeReference(uint.MaxValue));
+            Assert.AreEqual(String.Format("string:{0}, ByteBlock:{0}, double:{0}, float:2.1474836E+09, ulong:{0}, long:{0}, uint:{0}, int:{0}", int.MaxValue), TryAllConversions(int.MaxValue));
+            Assert.AreEqual(String.Format("string:{0}, ByteBlock:{0}, double:{0}, float:2.1474836E+09, ulong:{0}, long:{0}, uint:{0}, int:{0}", int.MaxValue), TryAllConversions_ValueTypeReference(int.MaxValue));
             Assert.AreEqual(String.Format("string:{0}, ByteBlock:{0}, double:{0}, float:{0}, ulong:{0}, long:{0}, uint:{0}, int:{0}, ushort:{0}", ushort.MaxValue), TryAllConversions(ushort.MaxValue));
             Assert.AreEqual(String.Format("string:{0}, ByteBlock:{0}, double:{0}, float:{0}, ulong:{0}, long:{0}, uint:{0}, int:{0}, ushort:{0}", ushort.MaxValue), TryAllConversions_ValueTypeReference(ushort.MaxValue));
             Assert.AreEqual(String.Format("string:{0}, ByteBlock:{0}, double:{0}, float:{0}, ulong:{0}, long:{0}, uint:{0}, int:{0}, ushort:{0}, short:{0}", short.MaxValue), TryAllConversions(short.MaxValue));
@@ -78,12 +78,12 @@ namespace Arriba.Test.Structures
             Assert.AreEqual(String.Format("string:{0}, ByteBlock:{0}, double:{0}, float:{0}, long:{0}, int:{0}, short:{0}", -1), TryAllConversions_ValueTypeReference(-1));
             Assert.AreEqual(String.Format("string:{0}, ByteBlock:{0}, double:{0}, float:{0}, long:{0}, int:{0}, short:{0}", short.MinValue), TryAllConversions(short.MinValue));
             Assert.AreEqual(String.Format("string:{0}, ByteBlock:{0}, double:{0}, float:{0}, long:{0}, int:{0}, short:{0}", short.MinValue), TryAllConversions_ValueTypeReference(short.MinValue));
-            Assert.AreEqual(String.Format("string:{0}, ByteBlock:{0}, double:{0}, float:-2.147484E+09, long:{0}, int:{0}", int.MinValue), TryAllConversions(int.MinValue));
-            Assert.AreEqual(String.Format("string:{0}, ByteBlock:{0}, double:{0}, float:-2.147484E+09, long:{0}, int:{0}", int.MinValue), TryAllConversions_ValueTypeReference(int.MinValue));
-            Assert.AreEqual(String.Format("string:{0}, ByteBlock:{0}, double:-9.22337203685478E+18, float:-9.223372E+18, long:{0}", long.MinValue), TryAllConversions(long.MinValue));
-            Assert.AreEqual(String.Format("string:{0}, ByteBlock:{0}, double:-9.22337203685478E+18, float:-9.223372E+18, long:{0}", long.MinValue), TryAllConversions_ValueTypeReference(long.MinValue));
-            Assert.AreEqual(String.Format("string:{0}, ByteBlock:{0}, double:-3.40282346638529E+38, float:{0}", float.MinValue), TryAllConversions(float.MinValue));
-            Assert.AreEqual(String.Format("string:{0}, ByteBlock:{0}, double:-3.40282346638529E+38, float:{0}", float.MinValue), TryAllConversions_ValueTypeReference(float.MinValue));
+            Assert.AreEqual(String.Format("string:{0}, ByteBlock:{0}, double:{0}, float:-2.1474836E+09, long:{0}, int:{0}", int.MinValue), TryAllConversions(int.MinValue));
+            Assert.AreEqual(String.Format("string:{0}, ByteBlock:{0}, double:{0}, float:-2.1474836E+09, long:{0}, int:{0}", int.MinValue), TryAllConversions_ValueTypeReference(int.MinValue));
+            Assert.AreEqual(String.Format("string:{0}, ByteBlock:{0}, double:-9.223372036854776E+18, float:-9.223372E+18, long:{0}", long.MinValue), TryAllConversions(long.MinValue));
+            Assert.AreEqual(String.Format("string:{0}, ByteBlock:{0}, double:-9.223372036854776E+18, float:-9.223372E+18, long:{0}", long.MinValue), TryAllConversions_ValueTypeReference(long.MinValue));
+            Assert.AreEqual(String.Format("string:{0}, ByteBlock:{0}, double:-3.4028234663852886E+38, float:{0}", float.MinValue), TryAllConversions(float.MinValue));
+            Assert.AreEqual(String.Format("string:{0}, ByteBlock:{0}, double:-3.4028234663852886E+38, float:{0}", float.MinValue), TryAllConversions_ValueTypeReference(float.MinValue));
             Assert.AreEqual(String.Format("string:{0}, ByteBlock:{0}, double:{0}", double.MinValue), TryAllConversions(double.MinValue));
             Assert.AreEqual(String.Format("string:{0}, ByteBlock:{0}, double:{0}", double.MinValue), TryAllConversions_ValueTypeReference(double.MinValue));
 

--- a/src/Arriba/Arriba.Test/Structures/ValueTests.cs
+++ b/src/Arriba/Arriba.Test/Structures/ValueTests.cs
@@ -17,7 +17,6 @@ namespace Arriba.Test.Structures
     public class ValueTests
     {
         [TestMethod]
-        [Ignore("Needs fix while converting to dotnetcore")]
         public void Value_Basic()
         {
             // Null


### PR DESCRIPTION
During the conversion to .Net Core some test was failing and disabled to perform a further investigation later, the time has come to enable and fix them.